### PR TITLE
Fix: set package.json types path to dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "files": [
     "dist"
   ],
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "module": "dist/index.es.js",
   "main": "dist/index.js",
   "jest": {


### PR DESCRIPTION
Otherwise `tsc` won't be able to find the type declarations when run in projects using this library.